### PR TITLE
Fix hardcoded menu weight leading to conflict

### DIFF
--- a/contactinactive.php
+++ b/contactinactive.php
@@ -137,15 +137,15 @@ function contactinactive_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) 
   _contactinactive_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
-function contactinactive_civicrm_summaryActions(&$actions, $contactId){
-    $actions['contactinactive'] = [
-      'title' => 'Set to Inactive',
-      'weight' => 999,
-      'ref' => 'contact-inactive',
-      'key' => 'contact-inactive',
-      'href' => CRM_Utils_System::url('civicrm/contact/setinactive', "cid=$contactId"),
-      'tab' => 'summary',
-    ];
+function contactinactive_civicrm_summaryActions(&$actions, $contactId) {
+  $actions['contactinactive'] = [
+    'title'  => 'Set to Inactive',
+    'weight' => max(array_column($actions, 'weight')) + 999,
+    'ref'    => 'contact-inactive',
+    'key'    => 'contact-inactive',
+    'href'   => CRM_Utils_System::url('civicrm/contact/setinactive', "cid=$contactId"),
+    'tab'    => 'summary',
+  ];
 }
 
 function contactinactive_civicrm_searchTasks( $objectName, &$tasks ){


### PR DESCRIPTION
Fixes an issue where the hardcoded summary action weight may cause conflicts with other extensions (e.g. `org.wikimedia.contacteditor`).